### PR TITLE
Refactor Vocabulary Media File Handling

### DIFF
--- a/src/models/vocabulary/request/index.ts
+++ b/src/models/vocabulary/request/index.ts
@@ -11,8 +11,8 @@ export const CreateVocabularyFullMultipartSchema = z.object({
         TranslationsSchema
     ]),
     // Optional media files for multipart submission
-    image: z.any().optional(),
-    audio: z.any().optional(),
+    imageFile: z.any().optional(),
+    audioFile: z.any().optional(),
 })
 
 export type ICreateVocabularyFullMultipartType = z.infer<typeof CreateVocabularyFullMultipartSchema>

--- a/src/pages/AdminPage/Vocabulary/components/CreateVocabulary/index.tsx
+++ b/src/pages/AdminPage/Vocabulary/components/CreateVocabulary/index.tsx
@@ -43,8 +43,8 @@ const CreateVocabulary = ({ setIsAddDialogOpen }: CreateVocabularyProps) => {
             level_n: '',
             word_type_id: '',
             translations: '',
-            image: undefined,
-            audio: undefined,
+            imageFile: undefined,
+            audioFile: undefined,
         }
     });
 
@@ -118,10 +118,10 @@ const CreateVocabulary = ({ setIsAddDialogOpen }: CreateVocabularyProps) => {
             const submitPayload: any = {
                 ...data,
             };
-            const imageFile: File | undefined = (watch('image') as any) as File | undefined;
-            const audioFile: File | undefined = (watch('audio') as any) as File | undefined;
-            if (imageFile) submitPayload.image = imageFile;
-            if (audioFile) submitPayload.audio = audioFile;
+            const imageFile: File | undefined = (watch('imageFile') as any) as File | undefined;
+            const audioFile: File | undefined = (watch('audioFile') as any) as File | undefined;
+            if (imageFile) submitPayload.imageFile = imageFile;
+            if (audioFile) submitPayload.audioFile = audioFile;
             createVocabularyMutation.mutate(submitPayload as ICreateVocabularyFullMultipartType);
         } catch (error: any) {
             setIsSubmitting(false);
@@ -546,7 +546,7 @@ const CreateVocabulary = ({ setIsAddDialogOpen }: CreateVocabularyProps) => {
                                 </CardHeader>
                                 <CardContent className="pt-0 grid grid-cols-1 md:grid-cols-2 gap-6">
                                     <Controller
-                                        name="image"
+                                        name="imageFile"
                                         control={control}
                                         render={({ field: { onChange, value } }) => (
                                             <ImageDropzone value={value} onChange={(file) => {
@@ -557,7 +557,7 @@ const CreateVocabulary = ({ setIsAddDialogOpen }: CreateVocabularyProps) => {
                                         )}
                                     />
                                     <Controller
-                                        name="audio"
+                                        name="audioFile"
                                         control={control}
                                         render={({ field: { onChange, value } }) => (
                                             <AudioDropzone value={value as File | undefined} onChange={(file) => {

--- a/src/services/vocabulary/index.ts
+++ b/src/services/vocabulary/index.ts
@@ -21,11 +21,11 @@ const vocabularyService = {
         formData.append("translations", translationsValue);
 
         // Optional media files
-        if ((payload as any).image) {
-            formData.append("image", (payload as any).image as File);
+        if ((payload as any).imageFile) {
+            formData.append("imageFile", (payload as any).imageFile as File);
         }
-        if ((payload as any).audio) {
-            formData.append("audio", (payload as any).audio as File);
+        if ((payload as any).audioFile) {
+            formData.append("audioFile", (payload as any).audioFile as File);
         }
 
         return axiosPrivate.post("/vocabulary/full", formData, {


### PR DESCRIPTION
- Renamed media file properties from 'image' and 'audio' to 'imageFile' and 'audioFile' in the CreateVocabularyFullMultipartSchema for clarity.
- Updated the CreateVocabulary component to reflect these changes in state management and form submission.
- Adjusted the vocabulary service to handle the new property names when appending files to the form data.